### PR TITLE
add react linting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save-dev @twostoryrobot/eslint
 Make sure to install the peer dependencies
 
 ```bash
-npm install --save-dev eslint eslint-plugin-jest
+npm install --save-dev eslint eslint-plugin-jest eslint-plugin-react
 ```
 
 ### Scripts

--- a/eslint.js
+++ b/eslint.js
@@ -2,18 +2,27 @@ module.exports = {
   env: {
     es6: true,
     node: true,
-    jest: true
+    jest: true,
+    browser: true
   },
   parserOptions: {
-    ecmaVersion: 2017
+    ecmaVersion: 2017,
+    ecmaFeatures: {
+      jsx: true
+    },
+    sourceType: "module"
   },
-  plugins: ['jest'],
-  extends: ['eslint:recommended', 'plugin:jest/recommended'],
+  plugins: ["jest", "react"],
+  extends: [
+    "eslint:recommended",
+    "plugin:jest/recommended",
+    "plugin:react/recommended"
+  ],
   rules: {
-    indent: ['error', 2],
-    'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single'],
-    semi: ['error', 'never'],
-    'no-console': 'off'
+    indent: ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    quotes: ["error", "single"],
+    semi: ["error", "never"],
+    "no-console": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "peerDependencies": {
     "eslint": "^4.13.1",
-    "eslint-plugin-jest": "^21.4.3"
+    "eslint-plugin-jest": "^21.4.3",
+    "eslint-plugin-react": "^7.7.0"
   },
   "author": "Chad Fawcett <me@chadf.ca>",
   "license": "MIT",


### PR DESCRIPTION
This adds some config for React to eslint via [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)

It has some nice rules like detecting missing propTypes.

It defaults to a rule that requires `DisplayName` on components, which I think might not be a bad thing to aid in debugging (and it's a simple property on the class).

I've also set `browser: true` so it ignores references to browser globals like `window` and `document`

@chadfawcett I've tested this in fresh CRA, but not in any other app with more code. Thoughts on it?