### PR TITLE
Use eslint-config-prettier to fix conflicts with prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,6 @@ module.exports = {
   plugins: ['jest'],
   extends: ['eslint:recommended', 'plugin:jest/recommended', 'prettier'],
   rules: {
-    indent: ['error', 2],
-    'linebreak-style': ['error', 'unix'],
-    quotes: ['error', 'single', {
-      avoidEscape: true,
-    }],
-    semi: ['error', 'never'],
     'no-console': 'off'
   }
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
     ecmaVersion: 2018
   },
   plugins: ['jest'],
-  extends: ['eslint:recommended', 'plugin:jest/recommended'],
+  extends: ['eslint:recommended', 'plugin:jest/recommended', 'prettier'],
   rules: {
     indent: ['error', 2],
     'linebreak-style': ['error', 'unix'],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "peerDependencies": {
     "eslint": "^4.13.1",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jest": "^21.4.3",
     "eslint-plugin-react": "^7.7.0"
   },


### PR DESCRIPTION
Just extends `eslint-config-prettier` to make sure `prettier` and `eslint` play together nicely.

Resolves #15 