### PR TITLE
Add multiline-comment-style rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
   plugins: ['jest'],
   extends: ['eslint:recommended', 'plugin:jest/recommended', 'prettier'],
   rules: {
-    'no-console': 'off'
+    'no-console': 'off',
+    'multiline-comment-style': ['error', 'starred-block']
   }
 }


### PR DESCRIPTION
Based on conversation here: https://github.com/TwoStoryRobot/javascript/pull/3#discussion_r513066827

There is a preference on the team for starred-block comments. We should try an eslint rule to enforce this and see how we like it, as consistent styling for large sections like multiline comments will be more readable and streamline PRs so that they aren't hung up on styling discussions.
