### PR TITLE
Add eslint-plugin-jsx-a11y to check accessibility rules on JSX elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save-dev @twostoryrobot/eslint-config
 Make sure to install the peer dependencies
 
 ```bash
-npm install --save-dev eslint eslint-config-prettier eslint-plugin-jest eslint-plugin-react
+npm install --save-dev eslint eslint-config-prettier eslint-plugin-jest eslint-plugin-react eslint-plugin-jsx-a11y
 ```
 
 If you are using NPM >5 you can also do this:

--- a/index.js
+++ b/index.js
@@ -8,8 +8,13 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018
   },
-  plugins: ['jest'],
-  extends: ['eslint:recommended', 'plugin:jest/recommended', 'prettier'],
+  plugins: ['jest', 'jsx-a11y'],
+  extends: [
+    'eslint:recommended',
+    'plugin:jest/recommended',
+    'prettier',
+    'plugin:jsx-a11y/recommended'
+  ],
   rules: {
     'no-console': 'off',
     'multiline-comment-style': ['error', 'starred-block']

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "eslint": "^4.13.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jest": "^21.4.3",
-    "eslint-plugin-react": "^7.7.0"
+    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-jsx-a11y": "^6.4.1"
   },
   "author": "Chad Fawcett <me@chadf.ca>",
   "license": "MIT",


### PR DESCRIPTION
I'd like to propose we [eslint-plugin-jsx-ally](https://www.npmjs.com/package/eslint-plugin-jsx-a11y) to our default `eslint` config as a step towards establishing a more defined company accessibility standard. 