### PR TITLE
Extend react-app config and add instructions for CRA users

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,30 @@ If you are using NPM >5 you can also do this:
 
 Add `@twostoryrobot/eslint-config` (or just `@twostoryrobot`) or
 `@twostoryrobot/eslint-config/react` (no shortcut for the react config, sorry)
-to the `extends` of your `.eslintrc`.
+to the `extends` of your `.eslintrc`. If using create-react-app, you must make
+sure to configure eslint via `package.json` instead, to ensure it is used by the
+dev server. You can also remove the default `extends: ['react-app','react-app/jest'`],
+since this config also includes those rules.
 
 Example: `.eslintrc.js`:
 
 ```javascript
 module.exports = {
   extends: ['@twostoryrobot/eslint-config/react']
+}
+```
+
+Example: `package.json` if using CRA:
+
+```json
+{
+  ...
+  "eslintConfig": {
+    "extends": [
+      "@twostoryrobot/eslint-config/react"
+    ]
+  },
+  ...
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "eslint": "^4.13.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jest": "^21.4.3",
-    "eslint-plugin-react": "^7.7.0"
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-config-react-app": "6.0.0"
   },
   "author": "Chad Fawcett <me@chadf.ca>",
   "license": "MIT",

--- a/react.js
+++ b/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['./index.js', 'plugin:react/recommended'],
+  extends: ['./index.js', 'plugin:react/recommended', 'react-app'],
   env: {
     browser: true
   },

--- a/react.js
+++ b/react.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   plugins: ['react'],
   rules: {
-    'react/display-name': 'off'
+    'react/display-name': 'off',
+    'react/react-in-jsx-scope': 'off'
   }
 }


### PR DESCRIPTION
- Adds `react-app-eslint-config` as a peer dependency
- Disables the `react/react-in-jsx-scope` rule since new projects generated by create-react-app no longer import react in files that use JSX, after the introduction of JSX transform in React 17.