### PR TITLE
Add rules from #23

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:jest/recommended', 'prettier'],
   rules: {
     'no-console': 'off',
-    'multiline-comment-style': ['error', 'starred-block']
+    'multiline-comment-style': ['error', 'starred-block'],
+    'no-var': 'error',
+    'object-shorthand': 'error',
+    'prefer-arrow-callback': 'error',
+    'no-duplicate-imports': 'error',
+    'prefer-const': 'error'
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/eslint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Two Story Robot eslint configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Some of these have come up in review so felt like a good time to get this updated :)

There are a couple I skipped:
* `no-multiple-empty-lines` -> Unnecessary; enforced by prettier-config
* `dot-notation` -> On reflection I think we have some arguably valid use cases for this (specifically, we sometimes use these when interacting with objects from remote APIs that are not following camelCase, such as geoJson.features[0].properties['REGION_TITLE_NAME']) and I don't find the erronous use cases come up often in review, so I suggest we sit on this one for now to try to keep the config light as possible
* `quotes: 'single'` -> Unnecessary; enforced by prettier-config

All other rules are added. I'm trying to keep the file as light as we can to avoid doubling rules from multiple sources or making our config too restrictive, so my approach to style management is for 1) things that can be fixed automatically by prettier covered there, then 2) things that can be errored by eslint automatically in tests covered here, then finally 3) things that need a human touch to be documented in [TwoStoryRobot/javascript](https://github.com/TwoStoryRobot/javascript) for easy reference


Resolves #23 